### PR TITLE
Fix daemon not exiting when receiving SIGTERM.

### DIFF
--- a/scc/sccdaemon.py
+++ b/scc/sccdaemon.py
@@ -223,7 +223,9 @@ class SCCDaemon(Daemon):
 					time.sleep(5)
 		
 		if "DISPLAY" in os.environ:
-			threading.Thread(target=threaded).start()
+			t = threading.Thread(target=threaded)
+			t.daemon = True
+			t.start()
 		else:
 			log.warning("DISPLAY env variable not set. Some functionality will be unavailable")
 


### PR DESCRIPTION
Currently, when the daemon receives SIGTERM (like when daemon.sh stop is executed), it does not exit until the popen.communicate returns.  This fixes that by making that thread a daemon thread.