### PR TITLE
Update README to include Exherbo package

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Based on [Standalone Steam Controller Driver](https://github.com/ynsta/steamcont
 - Ubuntu (deb-based distros): in [OpenSUSE Build Service](http://software.opensuse.org/download.html?project=home%3Akozec&package=sc-controller).
 - Fedora, SUSE (rpm-based distros): in [OpenSUSE Build Service](http://software.opensuse.org/download.html?project=home%3Akozec&package=sc-controller).
 - Arch, Manjaro: in [AUR](https://aur.archlinux.org/packages/sc-controller-git/)
+- Exherbo: in [hardware](https://git.exherbo.org/summer/packages/input/sc-controller)
 
 ##### To run without package
 - download and extract [latest release](https://github.com/kozec/sc-controller/releases/latest)


### PR DESCRIPTION
I've created an exheres for Exherbo Linux living in our ::hardware repository, allowing to easily install sc-controller via our package manager.