### PR TITLE
multi-monitor setups: show osd on the monitor containing the active application

### DIFF
--- a/scc/osd/__init__.py
+++ b/scc/osd/__init__.py
@@ -163,6 +163,10 @@ class OSDWindow(Gtk.Window):
 		self.realize()
 		self.get_window().set_override_redirect(True)
 		x, y = self.position
+		screen = self.get_window().get_screen()
+		geometry = screen.get_monitor_geometry(screen.get_monitor_at_window(screen.get_active_window()))
+		x = x + geometry.x
+		y = y + geometry.y + geometry.height - self.get_window().get_height()
 		if x < 0:	# Negative X position is counted from right border
 			x = Gdk.Screen.width() - self.get_allocated_width() + x + 1
 		if y < 0:	# Negative Y position is counted from bottom border


### PR DESCRIPTION
Useful if you game on your tv and have no line of sight to the primary monitor.