### PR TITLE
Fix gyro resetting

### DIFF
--- a/scc/mapper.py
+++ b/scc/mapper.py
@@ -312,7 +312,7 @@ class Mapper(object):
 	
 	
 	def reset_gyros(self):
-		for a in self.profile.get_actions():
+		for a in self.profile.get_all_actions():
 			if isinstance(a, GyroAbsAction):
 				a.reset()
 	


### PR DESCRIPTION
Profile.get_actions was renamed to get_all_actions in b97cbbb767881329019349b05e0f375ebc52909b, but this was not changed here.