### PR TITLE
fix gyro forgetting settings / not initing right

### DIFF
--- a/scc/gui/ae/gyro_action.py
+++ b/scc/gui/ae/gyro_action.py
@@ -152,6 +152,8 @@ class GyroActionComponent(AEComponent):
 			return True
 		if is_gyro_enable(action):
 			action = action.mods[action.order[0]] or action.default
+			if isinstance(action, SensitivityModifier):
+				action = action.action
 		if isinstance(action, GyroAction):	# Takes GyroAbsAction as well
 			ap = action.parameters
 			if (len(ap) == 3 and not ap[1]) or len(ap) == 2:
@@ -254,10 +256,8 @@ class GyroActionComponent(AEComponent):
 				action = ModeModifier(getattr(SCButtons, button), action)
 		if key == "mouse":
 			self.editor.set_default_sensitivity(3.5, 3.5, 3.5)
-			self.editor.set_sensitivity(3.5, 3.5, 3.5)
 		else:
 			self.editor.set_default_sensitivity(1, 1, 1)
-			self.editor.set_sensitivity(1, 1, 1)
 		
 		self.editor.set_action(action)
 

--- a/scc/gui/ae/gyro_action.py
+++ b/scc/gui/ae/gyro_action.py
@@ -87,7 +87,7 @@ class GyroActionComponent(AEComponent):
 			if isinstance(action, SensitivityModifier) and isinstance(action.action, MouseAction):
 				# Mouse (Desktop)
 				self.select_gyro_output("mouse")
-				if len(action.parameters) > 0 and action.parameters[0] == YAW:
+				if len(action.action.parameters) > 0 and action.action.parameters[0] == YAW:
 					self.select_yaw_roll(YAW)
 				else:
 					self.select_yaw_roll(ROLL)


### PR DESCRIPTION
this fixes the bug where gyro settings dialog doesn't correctly populate with stored settings

it also fixes sensitivity always reverting to defaults (idk why that was there)

this probably solves #230