### PR TITLE
colors and style reloaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 .atomignore
 commit*
 *test.*
+.idea/
+out.svg

--- a/default_menus/.games.menu
+++ b/default_menus/.games.menu
@@ -1,3 +1,6 @@
 [{
+    "separator": true,
+    "name": "Games"
+}, {
     "generator" : "games"
 }]

--- a/default_menus/.windowlist.menu
+++ b/default_menus/.windowlist.menu
@@ -1,3 +1,6 @@
 [{
+    "separator": true,
+    "name": "Switch to"
+}, {
     "generator" : "windowlist"
 }]

--- a/default_menus/Profiles.menu
+++ b/default_menus/Profiles.menu
@@ -1,3 +1,6 @@
 [{
+    "separator": true,
+    "name": "All profiles"
+}, {
     "generator" : "profiles"
 }]

--- a/scc/config.py
+++ b/scc/config.py
@@ -68,24 +68,24 @@ class Config(object):
 		"enable_sniffing" : False,
 		# Colors used by OSD
 		"osd_colors": {
-			"background": "160c00",
-			"border": "00FF00",
-			"text": "00FF00",
-			"menuitem_border": "004000",
-			"menuitem_hilight": "000070",
-			"menuitem_hilight_text": "FFFFFF",
-			"menuitem_hilight_border": "00FF00",
-			"menuseparator": "109010",
+			"background": "101010",
+			"border": "101010",
+			"text": "16BF24",
+			"menuitem_border": "101010",
+			"menuitem_hilight": "202020",
+			"menuitem_hilight_text": "16FF26",
+			"menuitem_hilight_border": "16FF26",
+			"menuseparator": "2e3436",
 		},
 		# Colors used by on-screen keyboard
 		"osk_colors": {
-			'hilight' : '00688D',
-			'pressed' : '1A9485',
-			"button1" : "162082",
-			"button1_border" : "262b5e",
-			"button2" : "162d44",
-			"button2_border" : "27323e",
-			"text" : "ffffff"
+			'hilight' : '7A7A7A',
+			'pressed' : 'B0B0B0',
+			"button1" : "101010",
+			"button1_border" : "101010",
+			"button2" : "2e3436",
+			"button2_border" : "2e3436",
+			"text" : "16BF24"
 		},
 		# Colors used by gesture display. Unlike OSD and OSK, these are RGBA
 		"gesture_colors" : {
@@ -93,6 +93,8 @@ class Config(object):
 			"grid": "004000ff",
 			"line": "ffffff1a",
 		},
+		# TODO: Config for opacity
+		"windows_opacity": 0.95,
 		# See drivers/sc_dongle.py, read_serial method
 		"ignore_serials" : True,
 	}

--- a/scc/osd/__init__.py
+++ b/scc/osd/__init__.py
@@ -21,7 +21,12 @@ class OSDWindow(Gtk.Window):
 	CSS = """
 		#osd-message, #osd-menu, #osd-gesture, #osd-keyboard {
 			background-color: #%(background)s;
-			border: 6px #%(border)s double;
+			border: 6px #%(border)s solid;
+			opacity: 0.95;
+		}
+		
+		#osd-message {
+			border-left: 5px #%(menuitem_hilight_text)s solid;
 		}
 		
 		#osd-area {
@@ -32,7 +37,7 @@ class OSDWindow(Gtk.Window):
 			color: #%(text)s;
 			border: none;
 			font-size: xx-large;
-			margin: 15px 15px 15px 15px;
+			padding: 15px 15px 15px 15px;
 		}
 		
 		#osd-menu, #osd-gesture {

--- a/scc/osd/menu.py
+++ b/scc/osd/menu.py
@@ -407,8 +407,10 @@ class Menu(OSDWindow):
 			self._selected = self._submenu._selected
 			self.quit(self._submenu.get_exit_code())
 		self._submenu = None
-	
-	
+
+		log.info("opacity set to 0.95")
+		self.set_opacity(0.95)
+
 	def show_submenu(self, trash, trash2, trash3, menuitem):
 		""" Called when user chooses menu item pointing to submenu """
 		filename = find_menu(menuitem.filename)
@@ -432,7 +434,10 @@ class Menu(OSDWindow):
 			self._submenu.controller = self.controller
 			self._submenu.connect('destroy', self.on_submenu_closed)
 			self._submenu.show()
-	
+
+			log.info("opacity set to 0.35")
+			self.set_opacity(0.35)
+
 	
 	def _control_equals_cancel(self, daemon, x, y):
 		"""


### PR DESCRIPTION
Made these changes for your consideration. Minimal barely transparent menus and keyboard so it looks nice over game and is still clearly visible. Better looking messages.

![1](https://user-images.githubusercontent.com/17696117/30521934-6d1c8b16-9bc8-11e7-931a-da5e95465b7f.jpg)
![2](https://user-images.githubusercontent.com/17696117/30521932-6cf5c440-9bc8-11e7-848b-7d5796dd6754.jpg)
![3](https://user-images.githubusercontent.com/17696117/30521933-6cfa41fa-9bc8-11e7-993d-e1f06c0a2eae.jpg)

Used black and white colors so that text and highlight colors can be changed from green to blue, red etc. to represent different controllers if needed later.

There is a config option for opacity but it is not read from there. If you don't mind you do configuration part. There should be option to disable opacity if users are having performance issues.