### PR TITLE
tools: find_binary: Add the standard binary paths if they are not in PATH

### DIFF
--- a/scc/gui/app.py
+++ b/scc/gui/app.py
@@ -21,7 +21,7 @@ from scc.gui.ribar import RIBar
 from scc.constants import SCButtons, STICK, STICK_PAD_MAX
 from scc.constants import DAEMON_VERSION, LEFT, RIGHT
 from scc.tools import get_profile_name, profile_is_default, profile_is_override
-from scc.tools import check_access, find_profile, find_gksudo, nameof
+from scc.tools import check_access, find_profile, find_binary, find_gksudo, nameof
 from scc.paths import get_config_path, get_profiles_path
 from scc.actions import NoAction
 from scc.modifiers import NameModifier
@@ -178,11 +178,12 @@ class App(Gtk.Application, UserDataManager, BindingEditor):
 			msg += "\n"   + _('or click on "Fix Temporary" button to attempt fix that should work until next restart.')
 			ribar = self.show_error(msg)
 			gksudo = find_gksudo()
+			modprobe = find_binary("modprobe")
 			if gksudo and not hasattr(ribar, "_fix_tmp"):
 				button = Gtk.Button.new_with_label(_("Fix Temporary"))
 				ribar._fix_tmp = button
 				button.connect('clicked', self.apply_temporary_fix,
-					gksudo + ["modprobe", "uinput"],
+					gksudo + [modprobe, "uinput"],
 					_("This will load missing uinput module.")
 				)
 				ribar.add_button(button, -1)

--- a/scc/tools.py
+++ b/scc/tools.py
@@ -286,7 +286,12 @@ def find_binary(name):
 	if name.startswith("scc-autoswitch-daemon"):
 		# As above
 		return os.path.join(os.path.split(__file__)[0], "x11", "scc-autoswitch-daemon.py")
-	for i in os.environ['PATH'].split(":"):
+	user_path = os.environ['PATH'].split(":")
+	# Try to add the standard binary paths if not present in PATH
+	for d in ["/sbin", "/bin", "/usr/sbin", "/usr/bin"]:
+		if d not in user_path:
+			user_path.append(d)
+	for i in user_path:
 		path = os.path.join(i, name)
 		if os.path.exists(path):
 			return path


### PR DESCRIPTION
In Solus (and possibly some other distributions), the /sbin and /usr/sbin paths are not included in user's PATH as they require to be run as root. This commit adds the standard binary paths (as defined by the Filesystem Hierarchy Standard) as a fallback.