### PR TITLE
Finding share directory is more flexible.

### DIFF
--- a/scc/paths.py
+++ b/scc/paths.py
@@ -10,7 +10,7 @@ python can't handle.
 All this is needed since I want to have entire thing installable, runnable
 from source tarball *and* debugable in working folder.
 """
-import os, __main__
+import os, sys, __main__
 
 
 def get_config_path():
@@ -108,9 +108,10 @@ def get_share_path():
 	"""
 	if "SCC_SHARED" in os.environ:
 		return os.environ["SCC_SHARED"]
-	if os.path.exists("/usr/local/share/scc/"):
-		return "/usr/local/share/scc/"
-	return "/usr/share/scc/"
+	local = os.path.expanduser("~/.local/share/scc")
+	if os.path.isdir(local):
+		return local
+	return os.path.join(sys.prefix, "share/scc")
 
 
 def get_pid_file():

--- a/scc/paths.py
+++ b/scc/paths.py
@@ -108,9 +108,11 @@ def get_share_path():
 	"""
 	if "SCC_SHARED" in os.environ:
 		return os.environ["SCC_SHARED"]
-	local = os.path.expanduser("~/.local/share/scc")
-	if os.path.isdir(local):
-		return local
+	if os.path.exists("/usr/local/share/scc/"):
+		return "/usr/local/share/scc/"
+	user = os.path.expanduser("~/.local/share/scc")
+	if os.path.exists(user):
+		return user
 	return os.path.join(sys.prefix, "share/scc")
 
 


### PR DESCRIPTION
Finding the config directory now works after you run "python setup.py install" inside a virtualenv and then run the script from there. And also if you did "python setup.py --user".

This was a resource that I looked at, if you're interested:

https://stackoverflow.com/a/14211600