### PR TITLE
Look for share/scc relative to script directory.

### DIFF
--- a/scc/paths.py
+++ b/scc/paths.py
@@ -108,13 +108,10 @@ def get_share_path():
 	"""
 	if "SCC_SHARED" in os.environ:
 		return os.environ["SCC_SHARED"]
-	if os.path.exists("/usr/local/share/scc/"):
-		return "/usr/local/share/scc/"
-	user = os.path.expanduser("~/.local/share/scc")
-	if os.path.exists(user):
-		return user
-	return os.path.join(sys.prefix, "share/scc")
 
+	installation = os.path.join(sys.argv[0], '../../share/scc')
+	installation = os.path.realpath(installation)
+	return installation
 
 def get_pid_file():
 	"""


### PR DESCRIPTION
This is how you'd typically do it in a C/C++ app. It works for every situation I can imagine:

* when installed to /usr/local
* when installed to /usr
* when installed to ~ using "python setup.py install --user"
* when installed in a virtualenv
* when run as a portable app (still uses $SCC_SHARED)