### PR TITLE
Use env instead of an absolute path in some #!s

### DIFF
--- a/scc/mapper.py
+++ b/scc/mapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 from __future__ import unicode_literals
 
 from collections import deque

--- a/scc/osd/slave_mapper.py
+++ b/scc/osd/slave_mapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 """
 SC-Controller - Slave Mapper
 

--- a/scripts/scc
+++ b/scripts/scc
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 """
 Script that integrates everything SCC can do in one executable.
 Created so scc-* stuff doesn't polute /usr/bin.

--- a/scripts/scc-daemon
+++ b/scripts/scc-daemon
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 from scc.sccdaemon import SCCDaemon
 from scc.paths import get_pid_file, get_daemon_socket
 from scc.tools import init_logging


### PR DESCRIPTION
When the #! is `#!/usr/bin/python2` and sc-controller is installed in a virtualenv, the main `scc` binary doesn't actually run, because `scc.scripts` isn't available to the python binary in `/usr/bin/`

The `#!/usr/bin/env python2` convention seems to be used everywhere else in the codebase, so I figured this was just an oversight for these four cases.