### PR TITLE
[Bugfix] gyro_action.glade: Gyro stick emulation commands backwards 

### DIFF
--- a/glade/ae/gyro_action.glade
+++ b/glade/ae/gyro_action.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkAdjustment" id="adjSoftLevel">
@@ -48,22 +48,22 @@
         <col id="2">mouse_stick</col>
       </row>
       <row>
-        <col id="0">gyro(ABS_RX, [ABS_RY|None, ABS_RY])</col>
+        <col id="0">gyro(ABS_RY, [ABS_RX|None, ABS_RX])</col>
         <col id="1" translatable="yes">Right Stick (Camera)</col>
         <col id="2">right</col>
       </row>
       <row>
-        <col id="0">gyroabs(ABS_RX, [ABS_RY|None, ABS_RY])</col>
+        <col id="0">gyroabs(ABS_RY, [ABS_RX|None, ABS_RX])</col>
         <col id="1" translatable="yes">Right Stick (Absolute)</col>
         <col id="2">right_abs</col>
       </row>
       <row>
-        <col id="0">gyro(ABS_X, [ABS_Y|None,ABS_Y])</col>
+        <col id="0">gyro(ABS_Y, [ABS_X|None, ABS_X])</col>
         <col id="1" translatable="yes">Left Stick (Camera)</col>
         <col id="2">left</col>
       </row>
       <row>
-        <col id="0">gyroabs(ABS_X, [ABS_Y|None, ABS_Y])</col>
+        <col id="0">gyroabs(ABS_Y, [ABS_X|None, ABS_X])</col>
         <col id="1" translatable="yes">Left Stick (Absolute)</col>
         <col id="2">left_abs</col>
       </row>
@@ -154,7 +154,7 @@
         <property name="can_focus">False</property>
         <property name="hexpand">True</property>
         <property name="model">lstYawRoll</property>
-        <property name="active">1</property>
+        <property name="active">0</property>
         <signal name="changed" handler="send" swapped="no"/>
         <child>
           <object class="GtkCellRendererText" id="text1"/>


### PR DESCRIPTION
The stick emulation command inserts in lstOutputMode were backwards; now Y axis is on Pitch, and X axis is on Yaw/Roll.

Changed default X axis to Yaw.