### PR TITLE
[c] Remove old rotate stub register line

### DIFF
--- a/src/actions/_stubs.c
+++ b/src/actions/_stubs.c
@@ -206,7 +206,6 @@ void scc_actions_init_stub() {
 	scc_action_register(KW_RESETGYRO, &stub_constructor);
 	scc_action_register(KW_CLEAROSD, &stub_constructor);
 	scc_action_register(KW_OSD, &stub_constructor);
-	scc_action_register(KW_ROTATE, &stub_constructor);
 	scc_action_register(KW_GESTURES, &stub_constructor);
 	scc_action_register(KW_POSITION, &stub_constructor);
 	scc_action_register(KW_RESTART, &stub_constructor);


### PR DESCRIPTION
The old KW_ROTATE stub registration line is not needed anymore. Leaving it in caused errors about duplicate registrations. This change removes the old registration line from the _stubs.c.