### PR TITLE
Trigger click

### DIFF
--- a/scc/drivers/sc_dongle.py
+++ b/scc/drivers/sc_dongle.py
@@ -185,6 +185,12 @@ class SCController(Controller):
 	
 	
 	def input(self, idata):
+		if idata.rtrig >= 253 and (idata.buttons & SCButtons.RT == 0):
+			idata = idata._replace(rtrig=253)
+
+		if idata.ltrig >= 253 and (idata.buttons & SCButtons.LT == 0):
+			idata = idata._replace(ltrig=253)
+
 		old_state, self._old_state = self._old_state, idata
 		if self.mapper:
 			#if idata.buttons & SCButtons.LPAD:


### PR DESCRIPTION
I have put a small check to data that is sended to mapper, preventing sending the full value of the trigger before the click, even before the calibration.
This is just for show how it works on steam right now as mentioned on issue #599 