### PR TITLE
Added StartupWMClass on desktop file

### DIFF
--- a/scripts/sc-controller.desktop
+++ b/scripts/sc-controller.desktop
@@ -8,3 +8,4 @@ Type=Application
 Icon=sc-controller
 Categories=GTK;Settings;HardwareSettings;
 MimeType=application/x-steamcontrollerdb-profile;application/x-scc-profile;application/x-scc-profile-package;
+StartupWMClass=SC Controller


### PR DESCRIPTION
This solved problem with render icon on dock
Without this option draw status icon:
![image](https://user-images.githubusercontent.com/8083855/107729374-2c951380-6d0a-11eb-8335-33f36ff3c620.png)
