### PR TITLE
Apply pad squaring on keyboard only if not deck, lock LGRIP and DOTS when keyboard open

### DIFF
--- a/include/scc/client.h
+++ b/include/scc/client.h
@@ -112,6 +112,13 @@ DLL_EXPORT uint32_t sccc_get_controller_handle(SCCClient* c, const char* id);
 DLL_EXPORT const char* sccc_get_controller_id(SCCClient* c, int handle);
 
 /**
+ * Returns controller data of specified controller or NULL if id is invalid.
+ * Returned value should _not_ be deallocated by caller and will be available
+ * at least until next call to 'sccc_recieve'.
+ */
+DLL_EXPORT ControllerData * sccc_get_controller_data(SCCClient* c, const char* id);
+
+/**
  * Locks physical button, axis or pad. Events from locked sources are
  * sent to this client and processed using 'event' callback until
  * unlock_all() is called.

--- a/include/scc/controller.h
+++ b/include/scc/controller.h
@@ -10,6 +10,7 @@
 
 typedef struct Controller Controller;
 typedef struct ControllerInput ControllerInput;
+typedef struct ControllerData ControllerData;
 typedef struct Mapper Mapper;
 typedef struct HapticData HapticData;
 
@@ -100,6 +101,14 @@ struct Controller {
 	void				(*set_mapper)(Controller* c, Mapper* m);
 };
 
+typedef struct ControllerData {
+	uint32_t			handle;
+	char*				id;
+	char*				type;
+	ControllerFlags		flags;
+	char*				config_file;
+	bool				alive;
+} ControllerData;
 
 typedef uint16_t Axis;
 typedef uint16_t Keycode;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -5,14 +5,6 @@
 #include "scc/client.h"
 #include <stdint.h>
 
-typedef struct ControllerData {
-	uint32_t			handle;
-	char*				id;
-	char*				type;
-	ControllerFlags		flags;
-	char*				config_file;
-	bool				alive;
-} ControllerData;
 
 typedef LIST_TYPE(ControllerData) ControllerList;
 

--- a/src/client/controller.c
+++ b/src/client/controller.c
@@ -159,6 +159,23 @@ uint32_t sccc_get_controller_handle(SCCClient* _c, const char* id) {
 	return 0;
 }
 
+ControllerData * sccc_get_controller_data(SCCClient* _c, const char* id) {
+	struct _SCCClient* c = container_of(_c, struct _SCCClient, client);
+	// Not using Iterator here to avoid need to allocate it
+	if (id == NULL) {
+		if (list_len(c->controllers) > 0)
+			return c->controllers->items[0];
+	} else {
+		FOREACH_IN(ControllerData*, cd, c->controllers) {
+			if (strcmp(cd->id, id) == 0) {
+				// Got one
+				return cd;
+			}
+		}
+	}
+	return NULL;
+}
+
 bool sccc_unlock_all(SCCClient* _c) {
 	struct _SCCClient* c = container_of(_c, struct _SCCClient, client);
 	int32_t id = sccc_request(&c->client, "Unlock.");
@@ -175,6 +192,23 @@ const char* sccc_get_controller_id(SCCClient* _c, int handle) {
 	struct _SCCClient* c = container_of(_c, struct _SCCClient, client);
 	ControllerData* cd = get_data_by_handle(c, handle);
 	return cd->id;
+}
+
+char * sccc_get_controller_type(SCCClient* _c, const char* id) {
+	struct _SCCClient* c = container_of(_c, struct _SCCClient, client);
+	// Not using Iterator here to avoid need to allocate it
+	if (id == NULL) {
+		if (list_len(c->controllers) > 0)
+			return c->controllers->items[0]->type;
+	} else {
+		FOREACH_IN(ControllerData*, cd, c->controllers) {
+			if (strcmp(cd->id, id) == 0) {
+				// Got one
+				return cd->type;
+			}
+		}
+	}
+	return 0;
 }
 
 void controller_data_free(ControllerData* cd) {

--- a/src/osd/keyboard/init.c
+++ b/src/osd/keyboard/init.c
@@ -98,7 +98,14 @@ static void osd_keyboard_set_cursor_position(OSDKeyboard* kbd, int index, AxisVa
 	double x = (double)_x / (double)(STICK_PAD_MAX);
 	double y = (double)_y / (double)(STICK_PAD_MAX) * -1.0;
 	
-	circle_to_square(&x, &y);
+	// TODO not on every input
+	ControllerData * cd = sccc_get_controller_data(priv->client, priv->controller_id);
+	if(cd != NULL){
+		if(strcmp(cd->type, "deck") != 0){
+			circle_to_square(&x, &y);
+		}
+	}
+
 	x = clamp(
 		0,
 		(priv->limits[index].x0 + w * 0.5) + x * w * 0.5,

--- a/src/osd/keyboard/keyboard.h
+++ b/src/osd/keyboard/keyboard.h
@@ -39,6 +39,7 @@ typedef LIST_TYPE(HelpLine) HelpLineList;
 typedef struct _OSDKeyboardPrivate {
 	SCCClient*					client;
 	GSource*					client_src;
+	bool						square;
 	Mapper*						slave_mapper;
 	ButtonList					buttons;
 	GtkWidget*					draw_area;


### PR DESCRIPTION
for some reason locking LGRIP2 while KB open causes LGRIP to cease functioning