### PR TITLE
fix some build errors and broken symlink

### DIFF
--- a/images/RSTICK.svg
+++ b/images/RSTICK.svg
@@ -1,1 +1,1 @@
-button-images/LSTICK.bw.svg
+button-images/RSTICK.bw.svg

--- a/scc/drivers/remotepad_controller.c
+++ b/scc/drivers/remotepad_controller.c
@@ -28,7 +28,7 @@ inline static SCButton libretro_button_to_sc_button(int id) {
 	case RETRO_DEVICE_ID_JOYPAD_L2:			return B_LT;
 	case RETRO_DEVICE_ID_JOYPAD_R2:			return B_RT;
 	case RETRO_DEVICE_ID_JOYPAD_L3:			return B_STICKPRESS;
-	case RETRO_DEVICE_ID_JOYPAD_R3:			return B_RPAD;
+	case RETRO_DEVICE_ID_JOYPAD_R3:			return B_RPADPRESS;
 	default:
 		return 0;
 	}

--- a/scc/drivers/scc_future.h
+++ b/scc/drivers/scc_future.h
@@ -40,6 +40,16 @@ typedef enum SCButton {
 	_SCButton_padding = 0xFFFFFFFF	// uint32_t
 } SCButton;
 
+struct GyroInput {
+	GyroValue			gpitch;
+	GyroValue			groll;
+	GyroValue			gyaw;
+	GyroValue			q1;
+	GyroValue			q2;
+	GyroValue			q3;
+	GyroValue			q4;
+};
+
 struct ControllerInput {
 	SCButton				buttons;
 	union {


### PR DESCRIPTION
Code in `master` did not compile due to `struct GyroInput` and `B_RPAD` being undefined. Dug around and [this commit](https://github.com/kozec/sc-controller/commit/3ffe65fdb924ca5094cd1b660819c67f6684d7a3) seemed to have broken it. This diff is an educated guess based on that commit which allows it to build again.

After building, it would not install due to a broken symlink, which has also been fixed.