### PR TITLE
Enable keyboard and update RGBA handling of OSD colour config

### DIFF
--- a/make-win32-release.sh
+++ b/make-win32-release.sh
@@ -37,7 +37,7 @@ GTK_ICONS=(
 		ui/pan-end-symbolic.symbolic.png
 		ui/pan-up-symbolic.symbolic.png
 )
-DRIVERS=(sc_by_cable sc_dongle)
+DRIVERS=(sc_by_cable sc_dongle steamdeck)
 
 export PROCESSOR_ARCHITEW6432=x86
 # meson $1

--- a/make-win32-release.sh
+++ b/make-win32-release.sh
@@ -46,7 +46,7 @@ ninja -C $1 || exit 1
 mkdir -p release-win32/share/glib-2.0
 mkdir -p release-win32/python
 mkdir -p release-win32/lib
-cp -vnur share/* release-win32/share
+cp -vur share/* release-win32/share
 cp -vur python/scc release-win32/python
 cp -vnur /mingw32/lib/python2.7 release-win32/lib
 cp -vu python/gui_loader.py release-win32/python/
@@ -66,9 +66,11 @@ for dll in $(find $1 -name "*.dll" -and -not -name "libscc-drv*" -and -not -name
 	cp -vu $dll release-win32/ || exit 1
 done
 
+mkdir -p drivers/
 mkdir -p release-win32/drivers/
 for i in "${DRIVERS[@]}" ; do
 	cp -vu "$1/src/daemon/drivers/libscc-drv-$i.dll" release-win32/drivers/
+	cp -vu "$1/src/daemon/drivers/libscc-drv-$i.dll" drivers/
 done
 
 mkdir -p release-win32/menu-generators/

--- a/meson.build
+++ b/meson.build
@@ -171,6 +171,7 @@ run_target_env.append('PATH', meson.build_root())
 run_target_env.append('PATH', meson.build_root() / 'src' / 'client')
 run_target_env.append('PATH', meson.build_root() / 'src' / 'osd' / 'common')
 run_target_env.append('PATH', meson.build_root() / 'src' / 'osd' / 'menus')
+run_target_env.append('PATH', meson.build_root() / 'src' / 'osd' / 'keyboard')
 run_target_env.append('PATH', meson.build_root() / 'src' / 'virtual-device')
 run_target_env.append('LD_LIBRARY_PATH', meson.build_root())
 

--- a/python/scc/gui/global_settings.py
+++ b/python/scc/gui/global_settings.py
@@ -151,9 +151,9 @@ class GlobalSettings(Editor, UserDataManager, ComboSetter):
 	def _load_color(self, w, value):
 		""" Common part of load_colors """
 		if w:
-			success, color = Gdk.Color.parse("#%s" % (value,))
+			success, color = Gdk.Color.parse("%s" % (value,))
 			if not success:
-				success, color = Gdk.Color.parse("#%s" % (value,))
+				success, color = Gdk.Color.parse("%s" % (value,))
 			w.set_color(color)
 	
 	def load_colors(self):
@@ -277,11 +277,11 @@ class GlobalSettings(Editor, UserDataManager, ComboSetter):
 		for k in self.OSD_COLORS:
 			w = self.builder.get_object("cb%s" % (k,))
 			if w:
-				self.app.config["osd_colors"][k] = tohex(w.get_color())
+				self.app.config["osd_colors"][k] = '#{}'.format(tohex(w.get_color()))
 		for k in self.OSK_COLORS:
 			w = self.builder.get_object("cbosk_%s" % (k,))
 			if w:
-				self.app.config["osk_colors"][k] = tohex(w.get_color())
+				self.app.config["osk_colors"][k] = '#{}'.format(tohex(w.get_color()))
 		self.app.config["osd_color_theme"] = "None"
 		self.set_cb(cbOSDColorPreset, "None")
 		self.app.save_config()

--- a/share/osd_styles/Blue.colors.json
+++ b/share/osd_styles/Blue.colors.json
@@ -1,24 +1,24 @@
 {
 	"###" : "Colors used by OSD",
 	"osd_colors": {
-		"background": "101010",
-		"border": "0000DF",
-		"text": "4060FF",
-		"menuitem_border": "000015",
-		"menuitem_hilight": "000050",
-		"menuitem_hilight_text": "FFFFFF",
-		"menuitem_hilight_border": "0000FF",
-		"menuseparator": "505090"
+		"background": "#101010",
+		"border": "#0000DF",
+		"text": "#4060FF",
+		"menuitem_border": "#000015",
+		"menuitem_hilight": "#000050",
+		"menuitem_hilight_text": "#FFFFFF",
+		"menuitem_hilight_border": "#0000FF",
+		"menuseparator": "#505090"
 	},
 	
 	"###" : "Colors used by on-screen keyboard",
 	"osk_colors": {
-		"hilight" : "00688D",
-		"pressed" : "1A9485",
-		"button1" : "162082",
-		"button1_border" : "262b5e",
-		"button2" : "162d44",
-		"button2_border" : "27323e",
-		"text" : "ffffff"
+		"hilight" : "#00688D",
+		"pressed" : "#1A9485",
+		"button1" : "#162082",
+		"button1_border" : "#262b5e",
+		"button2" : "#162d44",
+		"button2_border" : "#27323e",
+		"text" : "#ffffff"
 	}
 }

--- a/share/osd_styles/Cyan.colors.json
+++ b/share/osd_styles/Cyan.colors.json
@@ -1,24 +1,24 @@
 {
 	"###" : "Colors used by OSD",
 	"osd_colors": {
-		"background": "101010",
-		"border": "00DFDF",
-		"text": "40F0FF",
-		"menuitem_border": "001515",
-		"menuitem_hilight": "005050",
-		"menuitem_hilight_text": "FFFFFF",
-		"menuitem_hilight_border": "00FFFF",
-		"menuseparator": "509090"
+		"background": "#101010",
+		"border": "#00DFDF",
+		"text": "#40F0FF",
+		"menuitem_border": "#001515",
+		"menuitem_hilight": "#005050",
+		"menuitem_hilight_text": "#FFFFFF",
+		"menuitem_hilight_border": "#00FFFF",
+		"menuseparator": "#509090"
 	},
 	
 	"###" : "Colors used by on-screen keyboard",
 	"osk_colors": {
-		"hilight" : "00688D",
-		"pressed" : "1A9485",
-		"button1" : "162082",
-		"button1_border" : "262b5e",
-		"button2" : "162d44",
-		"button2_border" : "27323e",
-		"text" : "ffffff"
+		"hilight" : "#00688D",
+		"pressed" : "#1A9485",
+		"button1" : "#162082",
+		"button1_border" : "#262b5e",
+		"button2" : "#162d44",
+		"button2_border" : "#27323e",
+		"text" : "#ffffff"
 	}
 }

--- a/share/osd_styles/Green.colors.json
+++ b/share/osd_styles/Green.colors.json
@@ -3,24 +3,24 @@
 	
 	"###" : "Colors used by OSD",
 	"osd_colors": {
-		"background": "101010",
-		"border": "00FF00",
-		"text": "16BF24",
-		"menuitem_border": "001500",
-		"menuitem_hilight": "000070",
-		"menuitem_hilight_text": "16FF26",
-		"menuitem_hilight_border": "00FF00",
-		"menuseparator": "109010"
+		"background": "#101010",
+		"border": "#00FF00",
+		"text": "#16BF24",
+		"menuitem_border": "#001500",
+		"menuitem_hilight": "#000070",
+		"menuitem_hilight_text": "#16FF26",
+		"menuitem_hilight_border": "#00FF00",
+		"menuseparator": "#109010"
 	},
 	
 	"###" : "Colors used by on-screen keyboard",
 	"osk_colors": {
-		"hilight" : "00688D",
-		"pressed" : "1A9485",
-		"button1" : "162082",
-		"button1_border" : "262b5e",
-		"button2" : "162d44",
-		"button2_border" : "27323e",
-		"text" : "ffffff"
+		"hilight" : "#00688D",
+		"pressed" : "#1A9485",
+		"button1" : "#162082",
+		"button1_border" : "#262b5e",
+		"button2" : "#162d44",
+		"button2_border" : "#27323e",
+		"text" : "#ffffff"
 	}
 }

--- a/share/osd_styles/Red.colors.json
+++ b/share/osd_styles/Red.colors.json
@@ -1,24 +1,24 @@
 {
 	"###" : "Colors used by OSD",
 	"osd_colors": {
-		"background": "101010",
-		"border": "DF0000",
-		"text": "FF2020",
-		"menuitem_border": "150000",
-		"menuitem_hilight": "600000",
-		"menuitem_hilight_text": "FFFFFF",
-		"menuitem_hilight_border": "FF0000",
-		"menuseparator": "905050"
+		"background": "#101010",
+		"border": "#DF0000",
+		"text": "#FF2020",
+		"menuitem_border": "#150000",
+		"menuitem_hilight": "#600000",
+		"menuitem_hilight_text": "#FFFFFF",
+		"menuitem_hilight_border": "#FF0000",
+		"menuseparator": "#905050"
 	},
 	
 	"###" : "Colors used by on-screen keyboard",
 	"osk_colors": {
-		"hilight" : "00688D",
-		"pressed" : "1A9485",
-		"button1" : "162082",
-		"button1_border" : "262b5e",
-		"button2" : "162d44",
-		"button2_border" : "27323e",
-		"text" : "ffffff"
+		"hilight" : "#00688D",
+		"pressed" : "#1A9485",
+		"button1" : "#162082",
+		"button1_border" : "#262b5e",
+		"button2" : "#162d44",
+		"button2_border" : "#27323e",
+		"text" : "#ffffff"
 	}
 }

--- a/share/osd_styles/Yellow.colors.json
+++ b/share/osd_styles/Yellow.colors.json
@@ -1,24 +1,24 @@
 {
 	"###" : "Colors used by OSD",
 	"osd_colors": {
-		"background": "101010",
-		"border": "FFFF00",
-		"text": "BFBF24",
-		"menuitem_border": "151500",
-		"menuitem_hilight": "FFFF00",
-		"menuitem_hilight_text": "000000",
-		"menuitem_hilight_border": "FFFF00",
-		"menuseparator": "A5A5A5"
+		"background": "#101010",
+		"border": "#FFFF00",
+		"text": "#BFBF24",
+		"menuitem_border": "#151500",
+		"menuitem_hilight": "#FFFF00",
+		"menuitem_hilight_text": "#000000",
+		"menuitem_hilight_border": "#FFFF00",
+		"menuseparator": "#A5A5A5"
 	},
 	
 	"###" : "Colors used by on-screen keyboard",
 	"osk_colors": {
-		"hilight" : "00688D",
-		"pressed" : "1A9485",
-		"button1" : "162082",
-		"button1_border" : "262b5e",
-		"button2" : "162d44",
-		"button2_border" : "27323e",
-		"text" : "ffffff"
+		"hilight" : "#00688D",
+		"pressed" : "#1A9485",
+		"button1" : "#162082",
+		"button1_border" : "#262b5e",
+		"button2" : "#162d44",
+		"button2_border" : "#27323e",
+		"text" : "#ffffff"
 	}
 }

--- a/src/gui/meson.build
+++ b/src/gui/meson.build
@@ -1,5 +1,5 @@
 deps = [ dependency('python-2.7') ]
-link = [ utils_lib, tools_lib ]
+link = [ utils_lib, tools_lib, bindings_lib ]
 sources = [ 'gui.c' ]
 link_args = []
 

--- a/src/osd/keyboard/display.c
+++ b/src/osd/keyboard/display.c
@@ -160,6 +160,16 @@ bool on_redraw(GtkWidget* draw_area, cairo_t* ctx, void* _priv) {
 					strbuilder_addf(label, "%lc", unicode);
 #else
 				char* str = scc_action_get_description(b->action, AC_OSD);
+				// TODO symbol change on shift
+				if (strlen(str) > 0) {
+					if (isascii(str[0])) {
+						if ((priv->mod_state & GDK_SHIFT_MASK) == GDK_SHIFT_MASK && isalpha(str[0])) {
+							str[0] = toupper(str[0]);
+						} else if (isalpha(str[0])) {
+							str[0] = tolower(str[0]);
+						}
+					} 
+				}
 				strbuilder_addf(label, "%s", str);
 				free(str);
 #endif

--- a/src/osd/keyboard/init.c
+++ b/src/osd/keyboard/init.c
@@ -199,6 +199,17 @@ int osd_keyboard_parse_args(OSDKeyboardOptions* options, int argc, char** argv) 
 	return 0;
 }
 
+static bool update(OSDKeyboardPrivate * priv) {
+	if(GetKeyState(VK_SHIFT) & 0x8000){
+		// modifier state incorrect on Windows, store bit
+		guint state = gdk_keymap_get_modifier_state(priv->keymap);
+		priv->mod_state = state | GDK_SHIFT_MASK;
+	} else {
+		priv->mod_state = 0;
+	}
+	return TRUE;
+}
+
 
 OSDKeyboard* osd_keyboard_new(OSDKeyboardOptions* options) {
 	SCCClient* client = sccc_connect();
@@ -253,6 +264,10 @@ OSDKeyboard* osd_keyboard_new(OSDKeyboardOptions* options) {
 	osd_keyboard_set_cursor_position(kbd, 1, 0, 0);
 	priv->cursors[0].pressed_button_index = -1;
 	priv->cursors[1].pressed_button_index = -1;
+
+	priv->mod_state = 0;	
+	g_timeout_add(100, (GSourceFunc) update, priv);
+
 	generate_help_lines(priv);
 	return kbd;
 

--- a/src/osd/keyboard/keyboard.h
+++ b/src/osd/keyboard/keyboard.h
@@ -61,6 +61,7 @@ typedef struct _OSDKeyboardPrivate {
 	GdkRGBA						color_button1;
 	GdkRGBA						color_button1_border;
 	GdkRGBA						color_text;
+	guint						mod_state;
 } OSDKeyboardPrivate;
 
 

--- a/src/osd/menus/radial_menu.c
+++ b/src/osd/menus/radial_menu.c
@@ -241,20 +241,47 @@ static bool on_redraw(GtkWidget* a, cairo_t* ctx, void* _mnu) {
 	return false;
 }
 
+const char * add_hex_hash(char * rgba_string) {
+	if (rgba_string[0] == '#') {
+		return rgba_string;
+	}
+	char * rgba_string_with_hash = malloc(strlen(rgba_string) + 2);
+	strcpy(rgba_string_with_hash, "#");
+	strcat(rgba_string_with_hash, rgba_string);
+	return rgba_string_with_hash;
+}
+
+const char * config_get_color_hex(Config * config, char * key) {
+	char * rgba_string = config_get(config, key);
+	if (rgba_string == NULL) {
+		return NULL;
+	}
+	const char * rgba_string_with_hash = add_hex_hash(rgba_string);
+	return rgba_string_with_hash;
+}
 
 void load_colors(struct RadialMenuData* data) {
 	Config* config = config_load();
 	ASSERT(config);
-	
-	gdk_rgba_parse(&data->color_background, config_get(config, "osd_colors/background"));
-	gdk_rgba_parse(&data->color_border, config_get(config, "osd_colors/border"));
-	gdk_rgba_parse(&data->color_text, config_get(config, "osd_colors/text"));
-	gdk_rgba_parse(&data->color_menuitem_border, config_get(config, "osd_colors/menuitem_border"));
-	gdk_rgba_parse(&data->color_menuitem_hilight, config_get(config, "osd_colors/menuitem_hilight"));
-	gdk_rgba_parse(&data->color_menuitem_hilight_text, config_get(config, "osd_colors/menuitem_hilight_text"));
-	gdk_rgba_parse(&data->color_menuitem_hilight_border, config_get(config, "osd_colors/menuitem_hilight_border"));
-	gdk_rgba_parse(&data->color_menuseparator, config_get(config, "osd_colors/menuseparator"));
-	
+
+	gdk_rgba_parse(&data->color_background, config_get_color_hex(config, "osd_colors/background"));
+	gdk_rgba_parse(&data->color_border, config_get_color_hex(config, "osd_colors/border"));
+	gdk_rgba_parse(&data->color_text, config_get_color_hex(config, "osd_colors/text"));
+	gdk_rgba_parse(&data->color_menuitem_border, config_get_color_hex(config, "osd_colors/menuitem_border"));
+	gdk_rgba_parse(&data->color_menuitem_hilight, config_get_color_hex(config, "osd_colors/menuitem_hilight"));
+	gdk_rgba_parse(&data->color_menuitem_hilight_text, config_get_color_hex(config, "osd_colors/menuitem_hilight_text"));
+	gdk_rgba_parse(&data->color_menuitem_hilight_border, config_get_color_hex(config, "osd_colors/menuitem_hilight_border"));
+	gdk_rgba_parse(&data->color_menuseparator, config_get_color_hex(config, "osd_colors/menuseparator"));
+
+	if(data->color_text.alpha == 0.0) {
+		DWARN("Text color from register/config not parsed correctly, change colour config to reset.");
+		// RGBA (108, 122, 137), 1
+		data->color_text.red = 0.4235294117647059;
+		data->color_text.green = 0.47843137254901963;
+		data->color_text.blue = 0.5372549019607843;
+		data->color_text.alpha = 1.0;
+	}
+		
 	RC_REL(config);
 }
 

--- a/src/osd/meson.build
+++ b/src/osd/meson.build
@@ -49,3 +49,9 @@ run_target('scc-osd-daemon',
 	env: run_target_env,
 )
 
+
+run_target('scc-osd-keyboard',
+	command: [scc_osd_keyboard],
+	depends: [scc_osd_keyboard],
+	env: run_target_env,
+)


### PR DESCRIPTION
Enables keyboard by default. Adds some code to be removed once users have switched to new proper colour code # prefix. A few meson build fixes related to file copying.
Fixes #716 