### PR TITLE
Feature: Allow configuration of UDP port

### DIFF
--- a/scc/cemuhook_server.c
+++ b/scc/cemuhook_server.c
@@ -346,8 +346,12 @@ bool sccd_cemuhook_socket_enable() {
 	memset(&server_addr, 0, sizeof(struct sockaddr_in));
 	server_addr.sin_family = AF_INET;
 	server_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
-	server_addr.sin_port = htons(26760);
-	
+	if (const char* custom_port = std::getenv("SERVER_PORT")) {
+		server_addr.sin_port = std::atoi(custom_port);
+	} else {
+		server_addr.sin_port = htons(26760);
+	}
+
 #ifdef _WIN32
 	WSADATA wsaData;
 	int err = WSAStartup(MAKEWORD(2, 2), &wsaData);

--- a/scc/cemuhook_server.c
+++ b/scc/cemuhook_server.c
@@ -346,8 +346,8 @@ bool sccd_cemuhook_socket_enable() {
 	memset(&server_addr, 0, sizeof(struct sockaddr_in));
 	server_addr.sin_family = AF_INET;
 	server_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
-	if (const char* custom_port = std::getenv("SCC_SERVER_PORT")) {
-		server_addr.sin_port = std::atoi(custom_port);
+	if (const char* custom_port = getenv("SCC_SERVER_PORT")) {
+		server_addr.sin_port = atoi(custom_port);
 	} else {
 		server_addr.sin_port = htons(26760);
 	}

--- a/scc/cemuhook_server.c
+++ b/scc/cemuhook_server.c
@@ -346,7 +346,7 @@ bool sccd_cemuhook_socket_enable() {
 	memset(&server_addr, 0, sizeof(struct sockaddr_in));
 	server_addr.sin_family = AF_INET;
 	server_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
-	if (const char* custom_port = std::getenv("SERVER_PORT")) {
+	if (const char* custom_port = std::getenv("SCC_SERVER_PORT")) {
 		server_addr.sin_port = std::atoi(custom_port);
 	} else {
 		server_addr.sin_port = htons(26760);

--- a/scc/cemuhook_server.py
+++ b/scc/cemuhook_server.py
@@ -47,7 +47,7 @@ class CemuhookServer:
 		poller = daemon.get_poller()
 		daemon.poller.register(self.socket.fileno(), poller.POLLIN, self.on_data_recieved)
 		
-		server_port = os.getenv('SERVER_PORT') or PORT;
+		server_port = os.getenv('SCC_SERVER_PORT') or PORT;
 		self.socket.bind(('127.0.0.1', server_port))
 		log.info("Created CemuHookUDP Motion Provider")
 	

--- a/scc/cemuhook_server.py
+++ b/scc/cemuhook_server.py
@@ -10,7 +10,7 @@ from scc.tools import find_library
 from scc.lib.enum import IntEnum
 from ctypes import c_uint32, c_int, c_bool, c_char_p, c_size_t, c_float
 from ctypes import create_string_buffer
-import logging, socket
+import logging, os, socket
 log = logging.getLogger("CemuHook")
 
 BUFFER_SIZE = 1024
@@ -47,7 +47,8 @@ class CemuhookServer:
 		poller = daemon.get_poller()
 		daemon.poller.register(self.socket.fileno(), poller.POLLIN, self.on_data_recieved)
 		
-		self.socket.bind(('127.0.0.1', 26760))
+		server_port = os.getenv('SERVER_PORT') or PORT;
+		self.socket.bind(('127.0.0.1', server_port))
 		log.info("Created CemuHookUDP Motion Provider")
 	
 	


### PR DESCRIPTION
Making the UDP server port configurable simplifies running other cemuhook providers on the same host. It is probably not very important for most users, but it doesn't break anything either.

I'm maintaining [batocera-extra](https://github.com/git-developer/batocera-extra), a project that integrates multiple cemuhook servers into the retro gaming distribution batocera.

To keep the efforts as small as the benefit, an environment variable is used instead of a command line argument.