### PR TITLE
fix: correct Sucessfully→Successfully typo in menu.py

### DIFF
--- a/scc/osd/menu.py
+++ b/scc/osd/menu.py
@@ -413,7 +413,7 @@ class Menu(OSDWindow):
 	
 	def lock_inputs(self):
 		def success(*a):
-			log.error("Sucessfully locked input")
+			log.error("Successfully locked input")
 		locks = [ self._control_with, self._confirm_with, self._cancel_with ]
 		if self._control_with == "STICK":
 			if self.controller.get_flags() & ControllerFlags.HAS_DPAD != 0:


### PR DESCRIPTION
## Summary
Corrected the `Sucessfully` → `Successfully` typo in menu.py log message (line 416).

## Changes
- scc/osd/menu.py: Fixed log message typo

## Testing
- Python syntax check passed